### PR TITLE
[ticket/791] Fix SQL-Error when trying to rate an image on mssql

### DIFF
--- a/root/install/dbal_schema.php
+++ b/root/install/dbal_schema.php
@@ -295,19 +295,16 @@ class phpbb_gallery_dbal_schema
 		'rates'	=> array(
 			'full_name'		=> GALLERY_RATES_TABLE,
 			'added'			=> '0.0.0',
-			'modified'		=> '0.0.0',
+			'modified'		=> '1.1.0',
 			'structure'		=> array(
 				'COLUMNS'		=> array(
-					'rate_image_id'		=> array('UINT', NULL, 'auto_increment'),
+					'rate_image_id'		=> array('UINT', 0),
 					'rate_user_id'		=> array('UINT', 0),
 					'rate_user_ip'		=> array('VCHAR:40', ''),
 					'rate_point'		=> array('UINT:3', 0),
 				),
 				'KEYS'		=> array(
-					'rate_image_id'		=> array('INDEX', 'rate_image_id'),
-					'rate_user_id'		=> array('INDEX', 'rate_user_id'),
-					'rate_user_ip'		=> array('INDEX', 'rate_user_ip'),
-					'rate_point'		=> array('INDEX', 'rate_point'),
+					'rate_image_user'	=> array('UNIQUE', array('rate_image_id', 'rate_user_id')),
 				),
 			),
 		),

--- a/root/install/install_update.php
+++ b/root/install/install_update.php
@@ -420,6 +420,16 @@ class install_update extends module
 					array(GALLERY_COMMENTS_TABLE, 'comment_signature', array('BOOL', 0),),
 					array(GALLERY_ALBUMS_TABLE, 'album_feed', array('BOOL', 1),),
 				));
+				$umil->table_column_update(array(
+					array(GALLERY_RATES_TABLE, 'rate_image_id', array('UINT', 0)),
+				));
+				$umil->db_tools->sql_create_unique_index(GALLERY_RATES_TABLE, 'rate_image_user', array('rate_image_id', 'rate_user_id'));
+				$umil->table_index_remove(array(
+					array(GALLERY_RATES_TABLE, 'rate_image_id'),
+					array(GALLERY_RATES_TABLE, 'rate_user_id'),
+					array(GALLERY_RATES_TABLE, 'rate_user_ip'),
+					array(GALLERY_RATES_TABLE, 'rate_point'),
+				));
 			break;
 		}
 


### PR DESCRIPTION
The problem here was, that there was a false primary key set to the image_id, therefor an image could only be rated once or not at all, when IDENTITY_INSERT was set to OFF. I now removed the PRIMARY key and added a UNIQUE key for (image_id, user_id).

http://www.flying-bits.org/tracker.php?p=6&t=791
