### PR TITLE
[ticket/826] includes/gallery/user.php: Invalid argument supplied for for

### DIFF
--- a/root/includes/gallery/user.php
+++ b/root/includes/gallery/user.php
@@ -60,19 +60,18 @@ class phpbb_gallery_user
 	*/
 	public function load_data()
 	{
+		$this->entry_exists	= false;
 		$sql = 'SELECT *
 			FROM ' . GALLERY_USERS_TABLE . '
 			WHERE user_id = ' . $this->id;
 		$result = $this->db->sql_query($sql);
-		$row = $this->db->sql_fetchrow($result);
-		$this->db->sql_freeresult($result);
-
-		$this->entry_exists	= false;
-		if ($row !== false)
+		if ($row = $this->db->sql_fetchrow($result))
 		{
 			$this->data			= $this->validate_data($row);
 			$this->entry_exists	= true;
 		}
+		$this->db->sql_freeresult($result);
+
 	}
 
 	/**


### PR DESCRIPTION
[ticket/826] includes/gallery/user.php: Invalid argument supplied for foreach()

When the user does not have a row in the users table the return value is "NULL"
for MySQLi and not "false" like for MySQL.
Related phpBB ticket: http://tracker.phpbb.com/browse/PHPBB3-10307

http://www.flying-bits.org/tracker.php?p=6&t=826
